### PR TITLE
ci: add action to check thirdparty notices

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,22 +19,4 @@
 # Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
 # Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
 # Source: https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
-
-# User-specific stuff
-.idea/**/workspace.xml
-.idea/**/tasks.xml
-.idea/**/usage.statistics.xml
-.idea/**/dictionaries
-.idea/**/shelf
-
-# Generated files
-.idea/**/contentModel.xml
-
-# Sensitive or high-churn files
-.idea/**/dataSources/
-.idea/**/dataSources.ids
-.idea/**/dataSources.local.xml
-.idea/**/sqlDataSources.xml
-.idea/**/dynamic.xml
-.idea/**/uiDesigner.xml
-.idea/**/dbnavigator.xml
+.idea

--- a/actions/check-thirdparty-notice/action.yml
+++ b/actions/check-thirdparty-notice/action.yml
@@ -51,11 +51,11 @@ runs:
       uses: astral-sh/setup-uv@v6.1.0
     - name: Make sure a dependencies file path was provided
       run: |
-        if [[ -z "PACKAGE_FILE" ]] \
-        && [[ -z "COMPOSER_FILE" ]] \
-        && [[ -z "PIP_REQUIREMENTS_FILES" ]]; then
+        if [[ -z "$PACKAGE_FILE" ]] \
+        && [[ -z "$COMPOSER_FILE" ]] \
+        && [[ -z "$PIP_REQUIREMENTS_FILES" ]]; then
           echo "At least one of the inputs package-file, composer-file or pip-requirements-files must be provided";
-          false;
+          exit 1;
         fi
       env:
         PACKAGE_FILE: ${{ inputs.package-file }}"

--- a/actions/check-thirdparty-notice/action.yml
+++ b/actions/check-thirdparty-notice/action.yml
@@ -58,9 +58,9 @@ runs:
           exit 1;
         fi
       env:
-        PACKAGE_FILE: ${{ inputs.package-file }}"
-        COMPOSER_FILE: ${{ inputs.composer-file }}"
-        PIP_REQUIREMENTS_FILES: ${{ inputs.pip-requirements-files }}"
+        PACKAGE_FILE: ${{ inputs.package-file }}
+        COMPOSER_FILE: ${{ inputs.composer-file }}
+        PIP_REQUIREMENTS_FILES: ${{ inputs.pip-requirements-files }}
       shell: bash
 
     - name: Compose the arguments to the script

--- a/actions/check-thirdparty-notice/action.yml
+++ b/actions/check-thirdparty-notice/action.yml
@@ -1,0 +1,96 @@
+# SPDX-FileCopyrightText: Copyright (C) 2025 Opal Health Informatics Group at the Research Institute of the McGill University Health Centre <john.kildea@mcgill.ca>
+#
+# SPDX-License-Identifier: TBD
+
+# Ensures that declared project dependencies and the third-party notice in THIRDPARTY.md are in sync.
+# I.e., each dependency has to have a corresponding heading in the notice.
+# Warns about dependencies missing as well as dependencies that are declared in addition.
+#
+# Note: Currently only supports npm and composer.
+
+name: Check Thirdparty Notice
+description: Ensures that declared project dependencies and the third-party notice in THIRDPARTY.md are in sync.
+
+inputs:
+  package-file:
+    description: The filename of an npm package.json file (can be relative to the current working directory)
+    default: ""
+  composer-file:
+    description: The filename of a composer.json file (can be relative to the current working directory)
+    default: ""
+  pip-requirements-files:
+    description: |
+      The filename(s) of a requirements file (can be relative to the current working directory).
+      If specifying more than one file, separate with spaces.
+    default: ""
+  additional-dependencies:
+    description: |
+      Additional dependencies that are allowed to be listed in the third-party notice.
+      If specifying more than one package, separate with spaces.
+    default: ""
+
+runs:
+  using: "composite"
+  steps:
+    # Setup
+    - name: Clone the caller's repo to access dependency files and the third-party notice
+      uses: actions/checkout@v4.2.2
+      with:
+        persist-credentials: false
+    - name: Clone check_thirdparty_notice.py from the actions repo
+      uses: actions/checkout@v4.2.2
+      with:
+        # TODO testing
+        ref: SB.check-thirdparty-notice
+        repository: opalmedapps/actions
+        path: opalmedapps-actions
+        # See: https://github.com/actions/checkout?tab=readme-ov-file#fetch-only-a-single-file
+        sparse-checkout: |
+          actions/check-thirdparty-notice/check_thirdparty_notice.py
+        sparse-checkout-cone-mode: false
+        persist-credentials: false
+    - name: Install uv
+      uses: astral-sh/setup-uv@v6.1.0
+    - name: Make sure a dependencies file path was provided
+      run: |
+        if [[ -z "PACKAGE_FILE" ]] \
+        && [[ -z "COMPOSER_FILE" ]] \
+        && [[ -z "PIP_REQUIREMENTS_FILES" ]]; then
+          echo "At least one of the inputs package-file, composer-file or pip-requirements-files must be provided";
+          false;
+        fi
+      env:
+        PACKAGE_FILE: ${{ inputs.package-file }}"
+        COMPOSER_FILE: ${{ inputs.composer-file }}"
+        PIP_REQUIREMENTS_FILES: ${{ inputs.pip-requirements-files }}"
+      shell: bash
+
+    - name: Compose the arguments to the script
+      run: | # zizmor: ignore[github-env]
+        ARGS=
+        ARGS=${ARGS}${NPM:+ --npm $NPM}
+        ARGS=${ARGS}${COMPOSER:+ --composer $COMPOSER}
+        ARGS=${ARGS}${PIP_REQUIREMENTS:+ --pip $PIP_REQUIREMENTS}
+        ARGS=${ARGS}${ADDITIONAL_DEPENDENCIES:+ --additional-dependencies $ADDITIONAL_DEPENDENCIES}
+        echo "Arguments are: $ARGS"
+        echo ARGS="$ARGS" >> "$GITHUB_ENV"
+      env:
+        NPM: ${{ inputs.package-file }}
+        COMPOSER: ${{ inputs.composer-file }}
+        PIP_REQUIREMENTS: ${{ inputs.pip-requirements-files }}
+        ADDITIONAL_DEPENDENCIES: ${{ inputs.additional-dependencies }}
+      shell: bash
+
+    # TODO testing
+    - name: ls local
+      run: ls -la
+      shell: bash
+
+    # TODO testing
+    - name: ls actions
+      run: ls -la opalmedapps-actions
+      shell: bash
+
+    - name: Call the check_thirdparty_notice script
+      run: uv run opalmedapps-actions/actions/check-thirdparty-notice/check_thirdparty_notice.py $ARGS
+      shell: bash

--- a/actions/check-thirdparty-notice/action.yml
+++ b/actions/check-thirdparty-notice/action.yml
@@ -6,7 +6,7 @@
 # I.e., each dependency has to have a corresponding heading in the notice.
 # Warns about dependencies missing as well as dependencies that are declared in addition.
 #
-# Note: Currently only supports npm and composer.
+# Note: Currently supports npm, composer and pip.
 
 name: Check Thirdparty Notice
 description: Ensures that declared project dependencies and the third-party notice in THIRDPARTY.md are in sync.

--- a/actions/check-thirdparty-notice/action.yml
+++ b/actions/check-thirdparty-notice/action.yml
@@ -40,8 +40,6 @@ runs:
     - name: Clone check_thirdparty_notice.py from the actions repo
       uses: actions/checkout@v4.2.2
       with:
-        # TODO testing
-        ref: SB.check-thirdparty-notice
         repository: opalmedapps/actions
         path: opalmedapps-actions
         # See: https://github.com/actions/checkout?tab=readme-ov-file#fetch-only-a-single-file
@@ -79,16 +77,6 @@ runs:
         COMPOSER: ${{ inputs.composer-file }}
         PIP_REQUIREMENTS: ${{ inputs.pip-requirements-files }}
         ADDITIONAL_DEPENDENCIES: ${{ inputs.additional-dependencies }}
-      shell: bash
-
-    # TODO testing
-    - name: ls local
-      run: ls -la
-      shell: bash
-
-    # TODO testing
-    - name: ls actions
-      run: ls -la opalmedapps-actions
       shell: bash
 
     - name: Call the check_thirdparty_notice script

--- a/actions/check-thirdparty-notice/check_thirdparty_notice.py
+++ b/actions/check-thirdparty-notice/check_thirdparty_notice.py
@@ -1,0 +1,120 @@
+# SPDX-FileCopyrightText: Copyright (C) 2025 Opal Health Informatics Group at the Research Institute of the McGill University Health Centre <john.kildea@mcgill.ca>
+#
+# SPDX-License-Identifier: TBD
+
+# TODO: let Renovate update these dependencies somehow
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#     "beautifulsoup4==4.13.4",
+#     "markdown==3.8",
+#     "pip-requirements-parser==32.0.1",
+# ]
+# ///
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import bs4
+import markdown
+from pip_requirements_parser import RequirementsFile
+
+
+def valid_path(argument: str) -> Path:
+    file = Path(argument)
+    if not file.exists() or not file.is_file():
+        raise ValueError(f'{argument} is not a valid file')
+
+    return file
+
+
+def is_package_name(tag: bs4.Tag) -> bool:
+    # filter out accidental h2 elements when license text contains
+    # a heading followed by dashes
+    # which is also converted to h2
+    if tag.name == 'h2':
+        if tag.next_sibling and tag.next_sibling.next_sibling:
+            return tag.next_sibling.next_sibling.name == 'ul'
+
+    return False
+
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--pip', metavar='requirements-file', type=valid_path, nargs='+')
+parser.add_argument('--npm', metavar='package-file', type=valid_path)
+parser.add_argument('--composer', metavar='composer-file', type=valid_path)
+parser.add_argument(
+    '--additional-dependencies',
+    type=str,
+    nargs='+',
+    default=[],
+    help='Specify additional dependencies that are allowed in the third-party notice',
+)
+
+args = parser.parse_args(sys.argv[1:])
+
+if not (args.pip or args.npm or args.composer):
+    raise ValueError('One of --pip, --npm or --composer needs to be provided')
+
+# determine all dependencies
+dependencies: set[str] = set()
+
+if args.npm:
+    package_file: Path = args.npm
+    # load direct dependencies (excluding dev)
+    with package_file.open() as fd:
+        package_data = json.load(fd)
+
+    for package_name in package_data['dependencies']:
+        dependencies.add(package_name)
+
+if args.composer:
+    composer_file: Path = args.composer
+
+    # load direct dependencies (excluding dev)
+    with composer_file.open() as fd:
+        package_data = json.load(fd)
+
+        for package_name in package_data['require']:
+            # exclude php and its extensions
+            if package_name == 'php' or package_name.startswith('ext-'):
+                continue
+
+            dependencies.add(package_name)
+
+if args.pip:
+    requirements_files: list[Path] = args.pip
+
+    for requirements_file in requirements_files:
+        requirements = RequirementsFile.from_file(str(requirements_file), include_nested=True)
+
+        for requirement in requirements.requirements:
+            # some dependencies are capitalized: normalize their names
+            dependencies.add(requirement.req.name.lower())
+
+# parse third-party notice by converting it to HTML and reading the level 2 headings out
+with Path('THIRDPARTY.md').open() as fd:
+    notice_text = fd.read()
+
+html = markdown.markdown(notice_text)
+soup = bs4.BeautifulSoup(html, 'html.parser')
+
+dependencies_in_notice = {heading.text for heading in soup.find_all(is_package_name)}
+additional_dependencies = args.additional_dependencies
+
+for additional_dependency in additional_dependencies:
+    dependencies_in_notice.remove(additional_dependency)
+    print(f'Ignoring additional dependency in third-party notice: {additional_dependency}')
+
+if dependencies != dependencies_in_notice:
+    extra_in_dependencies = dependencies.difference(dependencies_in_notice)
+    extra_in_notice = dependencies_in_notice.difference(dependencies)
+
+    print('mismatch between declared dependencies in dependency files and THIRDPARTY.md found:')
+    print(f'dependencies only in dependency files: {", ".join(extra_in_dependencies)}')
+    print(f'dependencies only in third-party notice: {", ".join(extra_in_notice)}')
+
+    sys.exit(1)
+
+print('Everything is in sync!')


### PR DESCRIPTION
Converted the thirdparty notice check at `https://gitlab.com/opalmedapps/engineering/ci-templates/-/blob/main/templates/check-thirdparty-notice/template.yml` from GitLab CI/CD syntax to GitHub Actions, as an action that can be reused in our various repositories.