### PR TITLE
ci: disable uv cache in check-thirdparty-notice

### DIFF
--- a/actions/check-thirdparty-notice/action.yml
+++ b/actions/check-thirdparty-notice/action.yml
@@ -56,6 +56,9 @@ runs:
         GITHUB_ACTION_PATH: ${{ github.action_path }}
     - name: Install uv
       uses: astral-sh/setup-uv@v6.1.0
+      with:
+        # The cache isn't needed in non-python environments without a relevant requirements or lock file, and causes an unnecessary warning
+        enable-cache: false
 
     - name: Compose the arguments to the script
       id: script-arguments


### PR DESCRIPTION
The `uv` cache used in `check-thirdparty-notice` causes issues in non-python environments without a requirements or lock file. The following warning is shown:

```
Warning: No file matched to [**/*requirements*.txt,**/*requirements*.in,**/*constraints*.txt,**/*constraints*.in,**/pyproject.toml,**/uv.lock]. The cache will never get invalidated. Make sure you have checked out the target repository and configured the cache-dependency-glob input correctly.
```

This PR turns off the cache for that action, to avoid potential issues.