### PR TITLE
feat: add support for PEP 621 metadata in check-thirdparty-notice

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,42 +18,38 @@ permissions:
   contents: read
 
 jobs:
+  # Test all dependency types
   check-thirdparty-notice-test1:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5.0.0
         with:
           persist-credentials: false
-
-      # Initialize test data
       - run: |
           cp actions/check-thirdparty-notice/tests/* .
           mv THIRDPARTY_all.md THIRDPARTY.md
-
-      # Run the check-thirdparty-notice action on the test data
       - uses: ./actions/check-thirdparty-notice
         with:
           package-file: package.json
           composer-file: composer.json
+          pyproject-file: pyproject.toml
           pip-requirements-files: requirements.txt requirements2.txt
 
+  # Test pip requirements with relative includes
   check-thirdparty-notice-test2:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5.0.0
         with:
           persist-credentials: false
-
-      # Initialize test data
       - run: |
           cp actions/check-thirdparty-notice/tests/* .
           mv THIRDPARTY_pip.md THIRDPARTY.md
-
-      # Run the check-thirdparty-notice action on the test data
       - uses: ./actions/check-thirdparty-notice
         with:
-          pip-requirements-files: requirements.txt
+          pip-requirements-files: requirements2.txt
 
+  # Test pip requirements with additional dependencies
   check-thirdparty-notice-test3:
     runs-on: ubuntu-latest
     steps:

--- a/actions/check-thirdparty-notice/action.yml
+++ b/actions/check-thirdparty-notice/action.yml
@@ -18,6 +18,9 @@ inputs:
   composer-file:
     description: The filename of a composer.json file (can be relative to the current working directory)
     default: ""
+  pyproject-file:
+    description: The filename of a Python pyproject.toml file (can be relative to the current working directory).
+    default: ""
   pip-requirements-files:
     description: |
       The filename(s) of a requirements file (can be relative to the current working directory).
@@ -36,14 +39,16 @@ runs:
     - name: Make sure a dependencies file path was provided
       run: |
         if [[ -z "$PACKAGE_FILE" ]] \
+        && [[ -z "$PYPROJECT_FILE" ]] \
         && [[ -z "$COMPOSER_FILE" ]] \
         && [[ -z "$PIP_REQUIREMENTS_FILES" ]]; then
-          echo "At least one of the inputs package-file, composer-file or pip-requirements-files must be provided";
+          echo "At least one of the inputs package-file, composer-file, pyproject-file or pip-requirements-files must be provided";
           exit 1;
         fi
       env:
         PACKAGE_FILE: ${{ inputs.package-file }}
         COMPOSER_FILE: ${{ inputs.composer-file }}
+        PYPROJECT_FILE: ${{ inputs.pyproject-file }}
         PIP_REQUIREMENTS_FILES: ${{ inputs.pip-requirements-files }}
       shell: bash
 
@@ -66,6 +71,7 @@ runs:
         ARGS=
         ARGS=${ARGS}${NPM:+ --npm $NPM}
         ARGS=${ARGS}${COMPOSER:+ --composer $COMPOSER}
+        ARGS=${ARGS}${PYPROJECT:+ --pyproject $PYPROJECT}
         ARGS=${ARGS}${PIP_REQUIREMENTS:+ --pip $PIP_REQUIREMENTS}
         ARGS=${ARGS}${ADDITIONAL_DEPENDENCIES:+ --additional-dependencies $ADDITIONAL_DEPENDENCIES}
         echo "Arguments are: $ARGS"
@@ -73,6 +79,7 @@ runs:
       env:
         NPM: ${{ inputs.package-file }}
         COMPOSER: ${{ inputs.composer-file }}
+        PYPROJECT: ${{ inputs.pyproject-file }}
         PIP_REQUIREMENTS: ${{ inputs.pip-requirements-files }}
         ADDITIONAL_DEPENDENCIES: ${{ inputs.additional-dependencies }}
       shell: bash

--- a/actions/check-thirdparty-notice/tests/THIRDPARTY_all.md
+++ b/actions/check-thirdparty-notice/tests/THIRDPARTY_all.md
@@ -21,3 +21,11 @@ This is a test file and just lists expected package names without any actual con
 ## pillow
 
 - Specified as Pillow in the requirements file
+
+## django
+
+- [Homepage](https://www.djangoproject.com)
+
+## djangorestframework
+
+- Specified as an optional dependency

--- a/actions/check-thirdparty-notice/tests/THIRDPARTY_pip.md
+++ b/actions/check-thirdparty-notice/tests/THIRDPARTY_pip.md
@@ -5,3 +5,11 @@ This is a test file and just lists expected package names without any actual con
 ## fake-python-package
 
 - Repository: unknown
+
+## another-fake-python-package
+
+- Repository: unknown
+
+## pillow
+
+- Specified as Pillow in the requirements file

--- a/actions/check-thirdparty-notice/tests/THIRDPARTY_pyproject.md
+++ b/actions/check-thirdparty-notice/tests/THIRDPARTY_pyproject.md
@@ -1,0 +1,11 @@
+# Third-Party Notice
+
+This is a test file and just lists expected package names without any actual content.
+
+## django
+
+- [Homepage](https://www.djangoproject.com)
+
+## djangorestframework
+
+- Specified as an optional dependency

--- a/actions/check-thirdparty-notice/tests/pyproject.toml
+++ b/actions/check-thirdparty-notice/tests/pyproject.toml
@@ -1,0 +1,17 @@
+[project]
+name = "actions"
+version = "0.1.0"
+requires-python = ">=3.13"
+dependencies = [
+    "django==5.2.4",
+]
+
+[project.optional-dependencies]
+rest = [
+    "djangorestframework>=3.16.1",
+]
+
+[dependency-groups]
+dev = [
+    "ruff>=0.13.0",
+]


### PR DESCRIPTION
Add support to read PEP 621 (project metadata) from `pyproject.toml` files to gather dependencies (and optional dependencies) in `check-thirdparty-notice`.